### PR TITLE
docs: Vercel env setup for v0.2.0 (CSP/CORS, debug gating, AdSense gating)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,23 @@ DEBUG_ENDPOINTS_ENABLED=false
 # Logging
 # LOG_LEVEL controls server log verbosity: error | warn | info | debug
 LOG_LEVEL=info
+
+# Encryption (recommended in production)
+# 64-hex AES-256-GCM key for API key encryption
+# Generate with: `openssl rand -hex 32`
+API_ENCRYPTION_KEY=
+
+# AdSense (optional; enable only when configured)
+# Set both to enable AdSense in Preview/Production
+NEXT_PUBLIC_ADSENSE_ENABLED=false
+# Publisher ID without the `ca-pub-` prefix
+NEXT_PUBLIC_ADSENSE_PUBLISHER_ID=
 ```
+
+### Vercel Deployment Notes (v0.2.0)
+- Vercel sets `NODE_ENV` and `VERCEL_ENV` automatically; you do not need to define them.
+- Set `DEBUG_ENDPOINTS_ENABLED=false` in both Production and Preview to gate `/api/debug/*`.
+- See `VERCEL_ENV_SETUP.md` for the complete list and guidance.
 
 ## Agent Workflow Commands
 

--- a/VERCEL_ENV_SETUP.md
+++ b/VERCEL_ENV_SETUP.md
@@ -1,0 +1,39 @@
+# Vercel Environment Setup (v0.2.0)
+
+This release adds stricter CSP/CORS, gates debug endpoints, and gates AdSense by config. Set these variables in Vercel → Project → Settings → Environment Variables.
+
+## Required
+
+- GOOGLE_GEMINI_API_KEY: your Gemini API key
+- YOUTUBE_DATA_API_KEY: your YouTube Data API v3 key
+
+## Recommended
+
+- API_ENCRYPTION_KEY: 64‑hex key for AES‑256‑GCM encryption
+  - Generate: `openssl rand -hex 32`
+  - Scope: Server only (Production and Preview)
+
+## AdSense (Optional — enable only when ready)
+
+- NEXT_PUBLIC_ADSENSE_ENABLED: `true` or `false`
+- NEXT_PUBLIC_ADSENSE_PUBLISHER_ID: your numeric publisher id (no `ca-pub-` prefix)
+
+When both are set (and true), layout injects AdSense meta/script with a CSP nonce and loads the client component via dynamic import.
+
+## Debug Endpoints Gate
+
+- DEBUG_ENDPOINTS_ENABLED: `false` (default). Set `true` only if you intentionally need `/api/debug/*` in Preview/Production.
+
+## Supabase / NextAuth (if used by your deployment)
+
+- NEXT_PUBLIC_SUPABASE_URL
+- NEXT_PUBLIC_SUPABASE_ANON_KEY
+- NEXTAUTH_SECRET
+- NEXTAUTH_URL
+
+## Notes
+
+- NODE_ENV and VERCEL_ENV: Vercel sets these automatically (no need to define).
+- After changing env vars, trigger a redeploy to apply them.
+- CSP will include a per‑request nonce; preview/prod exclude `'unsafe-inline'` and `'unsafe-eval'`.
+


### PR DESCRIPTION
This PR adds a concise guide for configuring Vercel environment variables for v0.2.0.\n\nHighlights:\n- API_ENCRYPTION_KEY recommendation (64-hex; openssl rand -hex 32)\n- DEBUG_ENDPOINTS_ENABLED=false by default (gates /api/debug/*)\n- AdSense is opt-in: NEXT_PUBLIC_ADSENSE_ENABLED + NEXT_PUBLIC_ADSENSE_PUBLISHER_ID (no ca-pub- prefix)\n- Reminders: Vercel sets NODE_ENV and VERCEL_ENV automatically; redeploy after env changes\n\nFiles:\n- VERCEL_ENV_SETUP.md (new)\n- README.md (links + env section updates)